### PR TITLE
fixing typo for required python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-request
+requests
 


### PR DESCRIPTION
misspelled `requests` so this is to update it accordingly. 